### PR TITLE
Ensure temp files are always removed

### DIFF
--- a/pbm/storage/fs/fs.go
+++ b/pbm/storage/fs/fs.go
@@ -63,10 +63,7 @@ func (*FS) Type() storage.Type {
 	return storage.Filesystem
 }
 
-func (fs *FS) Save(name string, data io.Reader, _ int64) error {
-	filepath := path.Join(fs.root, name+".tmp")
-	finalpath := path.Join(fs.root, name)
-
+func WriteSync(filepath string, data io.Reader) error {
 	err := os.MkdirAll(path.Dir(filepath), os.ModeDir|0o755)
 	if err != nil {
 		return errors.Wrapf(err, "create path %s", path.Dir(filepath))
@@ -89,13 +86,18 @@ func (fs *FS) Save(name string, data io.Reader, _ int64) error {
 	}
 
 	err = fw.Sync()
-	if err != nil {
-		return errors.Wrapf(err, "sync file <%s>", filepath)
-	}
+	return errors.Wrapf(err, "sync file <%s>", filepath)
+}
 
-	err = fw.Close()
+
+func (fs *FS) Save(name string, data io.Reader, _ int64) error {
+	filepath := path.Join(fs.root, name+".tmp")
+	finalpath := path.Join(fs.root, name)
+
+	err := WriteSync(filepath, data)
 	if err != nil {
-		return errors.Wrapf(err, "close file <%s>", filepath)
+		os.Remove(filepath)
+		return errors.Wrapf(err, "write-sync %s", path.Dir(filepath))
 	}
 
 	err = os.Rename(filepath, finalpath)
@@ -172,30 +174,11 @@ func (fs *FS) Copy(src, dst string) error {
 
 	destFilename := path.Join(fs.root, dst+".tmp")
 	finalFilename := path.Join(fs.root, dst)
-	err = os.MkdirAll(path.Dir(destFilename), os.ModeDir|0o755)
-	if err != nil {
-		return errors.Wrap(err, "create dst dir")
-	}
 
-	to, err := os.Create(destFilename)
+	err = WriteSync(destFilename, from)
 	if err != nil {
-		return errors.Wrap(err, "create dst")
-	}
-	defer to.Close()
-
-	_, err = io.Copy(to, from)
-	if err != nil {
-		return errors.Wrapf(err, "copy to <%s>", destFilename)
-	}
-
-	err = to.Sync()
-	if err != nil {
-		return errors.Wrapf(err, "sync file <%s>", destFilename)
-	}
-
-	err = to.Close()
-	if err != nil {
-		return errors.Wrapf(err, "close file <%s>", destFilename)
+		os.Remove(destFilename)
+		return errors.Wrapf(err, "write-sync %s", path.Dir(destFilename))
 	}
 
 	err = os.Rename(destFilename, finalFilename)


### PR DESCRIPTION
@djhughes Can you check my homework before I submit changes to Percona?  Their observation was that my previous changes didn't attempt to clean up temporary files if there was a failure.

* Move write and flush operations to a common function `WriteSync()`
* Attempt to remove temporary filename if a failure is returned